### PR TITLE
fix(wind_icon): Accept any numeric value (double and int)

### DIFF
--- a/lib/src/wind_icon.dart
+++ b/lib/src/wind_icon.dart
@@ -22,7 +22,7 @@ import 'package:weather_icons/src/util/rotate.dart';
 ///       onPressed: () { }
 ///     );
 class WindIcon extends BoxedIcon {
-  final double degree;
+  final num degree;
 
   const WindIcon({
     @required this.degree,


### PR DESCRIPTION
I noticed that the degree property doesn't accept int values (.toDouble needs to be used). To fix that, the type of the variable "degree" needs to be changed to num to accept both int and double values.